### PR TITLE
Add initial fyde-cli docs

### DIFF
--- a/fyde-cli.md
+++ b/fyde-cli.md
@@ -1,0 +1,14 @@
+---
+title: Fyde CLI Client
+has_children: false
+nav_order: 5
+---
+# Fyde CLI Client
+
+The Fyde CLI Client, fyde-cli, provides some of the [Fyde Enterprise Console]({{ site.baseurl }}{% link fyde-enterprise-console/README.md %}) functionality as a command-line utility.
+
+Available for Linux, macOS and Windows, fyde-cli is designed with interactive usage and automation in mind.
+It can be used to obtain information from the Fyde Enterprise Console, such as access and security events, for processing by another system.
+
+The Fyde CLI Client is an open source project under active development.
+For installation instructions and documentation, please visit [fyde-cli on GitHub](https://github.com/fyde/fyde-cli).

--- a/glossary.md
+++ b/glossary.md
@@ -1,20 +1,22 @@
 ---
 title: Glossary
 has_children: false
-nav_order: 5
+nav_order: 6
 ---
 # Glossary
 
-- [Admin](#admin)
-- [Device](#device)
-- [Envoy Proxy](#envoy-proxy)
-- [Fyde Access Proxy](#fyde-access-proxy)
-- [Fyde Access Proxy enrollment link](#fyde-access-proxy-enrollment-link)
-- [Fyde App](#fyde-app)
-- [Fyde Enterprise Console](#fyde-enterprise-console)
-- [Fyde Proxy Orchestrator](#fyde-proxy-orchestrator)
-- [Fyde User Directory Connector](#fyde-user-directory-connector)
-- [User](#user)
+- [Glossary](#glossary)
+  - [Admin](#admin)
+  - [Device](#device)
+  - [Envoy Proxy](#envoy-proxy)
+  - [Fyde Access Proxy](#fyde-access-proxy)
+  - [Fyde Access Proxy enrollment link](#fyde-access-proxy-enrollment-link)
+  - [Fyde App](#fyde-app)
+  - [fyde-cli](#fyde-cli)
+  - [Fyde Enterprise Console](#fyde-enterprise-console)
+  - [Fyde Proxy Orchestrator](#fyde-proxy-orchestrator)
+  - [Fyde User Directory Connector](#fyde-user-directory-connector)
+  - [User](#user)
 
 ## Admin
 
@@ -43,6 +45,10 @@ Required by Fyde Access Proxy and used to bootstrap and authorize the service. O
 ## Fyde App
 
 Agent software installed in a user's device.
+
+## fyde-cli
+
+Command-line software used to interact with the Fyde Enterprise Console.
 
 ## Fyde Enterprise Console
 


### PR DESCRIPTION
This PR adds an initial section about fyde-cli, as mentioned in #59.

For now, it is purposefully small because fyde-cli is still undergoing many changes.

(Later we should discuss whether to keep the main fyde-cli documentation in this website or in the fyde-cli wiki. Currently the only documentation is its README, this is expected to change gradually. The wiki enables more convenient editing, but we can still periodically "export" to this website, e.g. every major version)