### PR TITLE
Improve cloudformation parameters

### DIFF
--- a/fyde-access-proxy/aws-cloudformation/fyde-access-proxy-aws-cf-asg.yaml
+++ b/fyde-access-proxy/aws-cloudformation/fyde-access-proxy-aws-cf-asg.yaml
@@ -11,6 +11,7 @@ Parameters:
     Type: String
     MinLength: '20'
     NoEcho: true
+    AllowedPattern: '^https:\/\/.*\.fyde\.com\/proxies.*proxy_auth_token.*$'
 
   FydeAccessProxyPublicPort:
     Description: Public port for this proxy (must match the value configured in the console for this proxy)

--- a/fyde-access-proxy/aws-cloudformation/fyde-access-proxy-aws-cf-asg.yaml
+++ b/fyde-access-proxy/aws-cloudformation/fyde-access-proxy-aws-cf-asg.yaml
@@ -22,18 +22,18 @@ Parameters:
 
   VpcId:
     Type: 'AWS::EC2::VPC::Id'
-    Description: VpcId of your existing Virtual Private Cloud (VPC)
+    Description: Select the Virtual Private Cloud (VPC) to use
     ConstraintDescription: >-
       must be the VPC Id of an existing Virtual Private Cloud. Outbound traffic
       for the default security group associated with this VPC should be enabled.
 
-  Subnets:
+  PublicSubnets:
     Type: 'List<AWS::EC2::Subnet::Id>'
-    Description: The list of SubnetIds in your Virtual Private Cloud (VPC)
+    Description: 'Select the SubnetIds to use. NOTE: Use Public Subnets only'
     ConstraintDescription: >-
       recomended to be a list of at least two existing subnets associated with at least
       two different availability zones. They should be residing in the selected
-      Virtual Private Cloud.
+      Virtual Private Cloud and should allow access to internet
 
   ASGMaxSize:
     Description: Enter the Max Size for the ASG
@@ -148,7 +148,7 @@ Resources:
   NLB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
-      Subnets: !Ref Subnets
+      Subnets: !Ref PublicSubnets
       Scheme: internet-facing
       Type: network
       Tags:
@@ -212,7 +212,7 @@ Resources:
   AutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
-      VPCZoneIdentifier: !Ref Subnets
+      VPCZoneIdentifier: !Ref PublicSubnets
       Cooldown: 120
       LaunchConfigurationName: !Ref LaunchConfig
       MaxSize: !Ref ASGMaxSize

--- a/fyde-access-proxy/aws-cloudformation/fyde-access-proxy-aws-cf-ecs-fargate.yaml
+++ b/fyde-access-proxy/aws-cloudformation/fyde-access-proxy-aws-cf-ecs-fargate.yaml
@@ -23,18 +23,18 @@ Parameters:
 
   vpcId:
     Type: AWS::EC2::VPC::Id
-    Description: vpcId of your existing Virtual Private Cloud (VPC)
+    Description: Select the Virtual Private Cloud (VPC) to use
     ConstraintDescription: >-
       must be the VPC Id of an existing Virtual Private Cloud. Outbound traffic
       for the default security group associated with this VPC should be enabled.
 
-  subnets:
-    Type: List<AWS::EC2::Subnet::Id>
-    Description: The list of SubnetIds in your Virtual Private Cloud (VPC)
+  publicSubnets:
+    Type: 'List<AWS::EC2::Subnet::Id>'
+    Description: 'Select the SubnetIds to use. NOTE: Use Public Subnets only'
     ConstraintDescription: >-
       recomended to be a list of at least two existing subnets associated with at least
       two different availability zones. They should be residing in the selected
-      Virtual Private Cloud.
+      Virtual Private Cloud and should allow access to internet
 
   orchestratorDesiredCapacity:
     Description: Enter the desired capacity for the Orchestrator nodes
@@ -104,7 +104,7 @@ Resources:
   nlb:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
-      Subnets: !Ref subnets
+      Subnets: !Ref publicSubnets
       Scheme: internet-facing
       Type: network
       Tags:
@@ -336,7 +336,7 @@ Resources:
           AssignPublicIp: ENABLED
           SecurityGroups:
             - !Ref orchestratorSg
-          Subnets: !Ref subnets
+          Subnets: !Ref publicSubnets
       DeploymentConfiguration:
         MaximumPercent: 200
         MinimumHealthyPercent: 100
@@ -463,7 +463,7 @@ Resources:
           AssignPublicIp: ENABLED
           SecurityGroups:
             - !Ref redisSg
-          Subnets: !Ref subnets
+          Subnets: !Ref publicSubnets
       DesiredCount: 1
       EnableECSManagedTags: false
       LaunchType: FARGATE
@@ -589,7 +589,7 @@ Resources:
           SecurityGroups:
             - !Ref envoySg
             - !Ref inboundSg
-          Subnets: !Ref subnets
+          Subnets: !Ref publicSubnets
       LoadBalancers:
         - ContainerName: fydeEnvoy
           ContainerPort: !Ref fydeAccessProxyPublicPort

--- a/fyde-access-proxy/aws-cloudformation/fyde-access-proxy-aws-cf-ecs-fargate.yaml
+++ b/fyde-access-proxy/aws-cloudformation/fyde-access-proxy-aws-cf-ecs-fargate.yaml
@@ -12,6 +12,7 @@ Parameters:
     Type: String
     MinLength: 20
     NoEcho: true
+    AllowedPattern: '^https:\/\/.*\.fyde\.com\/proxies.*proxy_auth_token.*$'
 
   fydeAccessProxyPublicPort:
     Description: Public port for this proxy (must match the value configured in the console for this proxy)


### PR DESCRIPTION
# Description

- Specify that we want public subnets in cloudformation template

    Quick win to help the user understand what type of subnet is required

- Add AllowedPattern to fydeAccessProxyToken in cloudformation templates

    If the user tries to input a wrong token wrong it will receive the following message while trying to finish the cloudformation wizard:

    ![image](https://user-images.githubusercontent.com/19713226/83569476-77744f80-a51c-11ea-8d6d-bdc77c75a5eb.png)
