### PR TITLE
Correct required docker-compose file format version

### DIFF
--- a/fyde-access-proxy/docker/docker-compose.yml
+++ b/fyde-access-proxy/docker/docker-compose.yml
@@ -1,6 +1,6 @@
 # Docker compose Fyde Access Proxy
 ---
-version: '3'
+version: '3.5'
 services:
 
   envoy-proxy:


### PR DESCRIPTION
Fix:

```sh
→ docker-compose up
ERROR: The Compose file './docker-compose.yml' is invalid because:
networks.fyde value Additional properties are not allowed ('name' was unexpected)
```