### PR TITLE
Add redis configuration for install script and CF template

### DIFF
--- a/docs/fyde-access-proxy/aws-cloudformation/fyde-access-proxy-aws-cf-asg.yaml
+++ b/docs/fyde-access-proxy/aws-cloudformation/fyde-access-proxy-aws-cf-asg.yaml
@@ -7,14 +7,16 @@ Description: >-
 Parameters:
 
   FydeAccessProxyToken:
-    Description: Fyde Access Proxy Token for this proxy (obtained from the console after proxy creation)
+    Description: >-
+      Fyde Access Proxy Token for this proxy (obtained from the console after proxy creation).
     Type: String
     MinLength: '20'
     NoEcho: true
     AllowedPattern: '^https:\/\/.*\.fyde\.com\/proxies.*proxy_auth_token.*$'
 
   FydeAccessProxyPublicPort:
-    Description: Public port for this proxy (must match the value configured in the console for this proxy)
+    Description: >-
+      Public port for this proxy (must match the value configured in the console for this proxy).
     Default: 443
     Type: Number
     MinValue: 1
@@ -22,14 +24,16 @@ Parameters:
 
   VpcId:
     Type: 'AWS::EC2::VPC::Id'
-    Description: Select the Virtual Private Cloud (VPC) to use
+    Description: Select the Virtual Private Cloud (VPC) to use.
     ConstraintDescription: >-
       must be the VPC Id of an existing Virtual Private Cloud. Outbound traffic
       for the default security group associated with this VPC should be enabled.
 
   NLBPublicSubnets:
     Type: 'List<AWS::EC2::Subnet::Id>'
-    Description: 'Select the Public Subnet Ids to use for the Network Load Balancer. NOTE: Use Public Subnets only'
+    Description: >-
+      Select the Public Subnet Ids to use for the Network Load Balancer.
+      NOTE: Use Public Subnets only.
     ConstraintDescription: >-
       recomended to be a list of at least two existing subnets associated with at least
       two different availability zones. They should be residing in the selected
@@ -37,44 +41,48 @@ Parameters:
 
   EC2Subnets:
     Type: 'List<AWS::EC2::Subnet::Id>'
-    Description: 'Select the Subnet Ids to use for the EC2 instances. NOTE: Use Private Subnets with NAT Gateway configured or Public Subnets'
+    Description: >-
+      Select the Subnet Ids to use for the EC2 instances.
+      NOTE: Use Private Subnets with NAT Gateway configured or Public Subnets.
     ConstraintDescription: >-
       recomended to be a list of at least two existing subnets associated with at least
       two different availability zones. They should be residing in the selected
       Virtual Private Cloud and should allow access to internet
 
-  AssociatePublicIpAddress:
-    Description: If you specify true, each instance in the Auto Scaling group receives a unique public IP address. Default is false.
+  EC2AssociatePublicIpAddress:
+    Description: >-
+      If you specify true, each instance in the Auto Scaling group receives a unique public IP address.
+      Default is false.
     Type: String
     Default: false
     AllowedValues:
       - false
       - true
 
-  ASGMaxSize:
+  EC2ASGMaxSize:
     Description: Enter the Max Size for the ASG
     Default: 3
     Type: Number
     MinValue: 1
 
-  ASGMinSize:
+  EC2ASGMinSize:
     Description: Enter the Min Size for the ASG
     Default: 2
     Type: Number
     MinValue: 1
 
-  ASGDesiredCapacity:
+  EC2ASGDesiredCapacity:
     Description: Enter the desired capacity for the ASG
     Default: 2
     Type: Number
     MinValue: 1
 
-  KeyName:
+  EC2KeyName:
     Description: EC2 instance key name
     Type: 'AWS::EC2::KeyPair::KeyName'
     ConstraintDescription: must be the name of an existing EC2 KeyPair
 
-  InstanceType:
+  EC2InstanceType:
     Description: EC2 instance type
     Type: String
     Default: t2.small
@@ -85,7 +93,22 @@ Parameters:
       - t2.large
     ConstraintDescription: must be a valid EC2 instance type.
 
+  RedisSubnets:
+    Type: 'List<AWS::EC2::Subnet::Id>'
+    Description: >-
+      Select the Subnet Ids to use for the redis instances.
+      Required although Redis is only created when EC2ASGDesiredCapacity is not 1.
+      NOTE: Use Private Subnets
+
+Conditions:
+
+  RedisRequired: !Not [!Equals [!Ref EC2ASGDesiredCapacity, 1]]
+
 Resources:
+
+#
+# Find AMI
+#
 
   DescribeImagesRole:
     Type: AWS::IAM::Role
@@ -151,6 +174,10 @@ Resources:
       Name: 'amazonlinux-2-base_*'
       Architecture: x86_64
 
+#
+# Secret
+#
+
   FydeEnrollmentToken:
     Type: 'AWS::SecretsManager::Secret'
     Properties:
@@ -160,6 +187,10 @@ Resources:
       Tags:
         - Key: Name
           Value: FydeAccessProxy
+
+#
+# NLB
+#
 
   NLB:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
@@ -198,21 +229,9 @@ Resources:
         - Key: Application
           Value: FydeAccessProxyASG
 
-  InboundNLBSecGroup:
-    Type: 'AWS::EC2::SecurityGroup'
-    Properties:
-      GroupDescription: Allow inbound access to NLB on the configured port
-      SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: !Ref FydeAccessProxyPublicPort
-          ToPort: !Ref FydeAccessProxyPublicPort
-          CidrIp: 0.0.0.0/0
-      VpcId: !Ref VpcId
-      Tags:
-        - Key: Name
-          Value: FydeAccessProxy
-        - Key: Application
-          Value: FydeAccessProxyASG
+#
+# Security Groups
+#
 
   InboundEC2SecGroup:
     Type: 'AWS::EC2::SecurityGroup'
@@ -244,15 +263,44 @@ Resources:
         - Key: Application
           Value: FydeAccessProxyASG
 
+  RedisSecGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Condition: RedisRequired
+    Properties:
+      GroupDescription: Used to allow FydeAccessProxy access to redis
+      VpcId: !Ref VpcId
+      Tags:
+        - Key: Name
+          Value: FydeAccessProxy
+        - Key: Application
+          Value: FydeAccessProxyASG
+
+  RedisSecGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: RedisRequired
+    Properties:
+      FromPort: 6379
+      ToPort: 6379
+      GroupId: !Ref RedisSecGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref RedisSecGroup
+
+#
+# Fyde Access Proxy Instances
+#
+
   AutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
+    UpdatePolicy:
+      AutoScalingRollingUpdate:
+        MaxBatchSize: 1
     Properties:
       VPCZoneIdentifier: !Ref EC2Subnets
       Cooldown: 120
       LaunchConfigurationName: !Ref LaunchConfig
-      MaxSize: !Ref ASGMaxSize
-      MinSize: !Ref ASGMinSize
-      DesiredCapacity: !Ref ASGDesiredCapacity
+      MaxSize: !Ref EC2ASGMaxSize
+      MinSize: !Ref EC2ASGMinSize
+      DesiredCapacity: !Ref EC2ASGDesiredCapacity
       HealthCheckType: ELB
       HealthCheckGracePeriod: 300
       TargetGroupARNs:
@@ -266,28 +314,40 @@ Resources:
         - Key: Application
           Value: FydeAccessProxyASG
           PropagateAtLaunch: 'true'
+        - Key: Redis
+          Value: !If [ RedisRequired, 'true', 'false' ]
+          PropagateAtLaunch: 'true'
 
   LaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-      AssociatePublicIpAddress: !Ref AssociatePublicIpAddress
-      KeyName: !Ref KeyName
+      AssociatePublicIpAddress: !Ref EC2AssociatePublicIpAddress
+      KeyName: !Ref EC2KeyName
       ImageId: !Ref FydeAccessProxyAmiLatest
       SecurityGroups:
         - !Ref InboundEC2SecGroup
         - !Ref ResourceSecGroup
-      InstanceType: !Ref InstanceType
+        - !If [ RedisRequired, !Ref RedisSecGroup, !Ref 'AWS::NoValue' ]
+      InstanceType: !Ref EC2InstanceType
       IamInstanceProfile: !Ref InstanceProfile
       UserData:
-        Fn::Base64: !Sub |
-          #!/bin/bash -xe
-          INSTALL_PATH="/tmp/fyde-access-proxy"
-          INSTALL_URL="https://url.fyde.me/install-fyde-proxy-linux"
-          mkdir -p "$INSTALL_PATH"
-          curl -fsSLo "$INSTALL_PATH/install-fyde-proxy-linux.sh" "$INSTALL_URL"
-          chmod +x "$INSTALL_PATH/install-fyde-proxy-linux.sh"
-          sudo "$INSTALL_PATH/install-fyde-proxy-linux.sh" -p ${FydeAccessProxyPublicPort} -u
-          rm -rf "$INSTALL_PATH"
+        Fn::Base64:
+          !Join
+            - "\n"
+            - - '#!/bin/bash'
+              - 'set -xeuo pipefail'
+              - 'curl -sL "https://url.fyde.me/install-fyde-proxy-linux" | bash -s -- \'
+              - '  -u \'
+              - !Join
+                - ' '
+                - - !Sub '  -p "${FydeAccessProxyPublicPort}"'
+                  - !If [ RedisRequired, '\', !Ref 'AWS::NoValue' ]
+              - !If [ RedisRequired, !Sub '  -r "${RedisCacheReplicationGroup.PrimaryEndPoint.Address}" \', !Ref 'AWS::NoValue' ]
+              - !If [ RedisRequired, !Sub '  -s "${RedisCacheReplicationGroup.PrimaryEndPoint.Port}"', !Ref 'AWS::NoValue' ]
+
+#
+# IAM
+#
 
   InstanceProfile:
     Type: 'AWS::IAM::InstanceProfile'
@@ -308,19 +368,71 @@ Resources:
             Action:
               - 'sts:AssumeRole'
       Path: /
-      Policies:
-        - PolicyName: GetFydeSecrets
-          PolicyDocument:
-            Statement:
-              - Effect: Allow
-                Action:
-                  - 'secretsmanager:DescribeSecret'
-                  - 'secretsmanager:GetSecretValue'
-                Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:fyde_*'
-              - Effect: Allow
-                Action:
-                  - 'secretsmanager:ListSecrets'
-                Resource: '*'
+
+  InstancePolicyFydeSecrets:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyName: GetFydeSecrets
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - 'secretsmanager:DescribeSecret'
+              - 'secretsmanager:GetSecretValue'
+            Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:fyde_*'
+          - Effect: Allow
+            Action:
+              - 'secretsmanager:ListSecrets'
+            Resource: '*'
+      Roles:
+        - !Ref InstanceRole
+
+  InstancePolicyRedis:
+    Type: 'AWS::IAM::Policy'
+    Condition: RedisRequired
+    Properties:
+      PolicyName: DiscoverRedisCluster
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: 'elasticache:DescribeCacheClusters'
+            Resource: !Sub 'arn:aws:elasticache:${AWS::Region}:${AWS::AccountId}:replicationgroup:${RedisCacheReplicationGroup}'
+      Roles:
+        - !Ref InstanceRole
+
+#
+# Redis
+#
+
+  RedisCacheReplicationGroup:
+    Type: 'AWS::ElastiCache::ReplicationGroup'
+    Condition: RedisRequired
+    Properties:
+      AutomaticFailoverEnabled: true
+      MultiAZEnabled: true
+      CacheNodeType: cache.t2.micro
+      CacheSubnetGroupName: !Ref RedisCacheSubnetGroup
+      Engine: redis
+      NumCacheClusters: 2
+      Port: 6379
+      ReplicationGroupDescription: Redis for Fyde Access Proxy
+      SecurityGroupIds:
+        - !Ref RedisSecGroup
+      Tags:
+        - Key: Name
+          Value: FydeAccessProxy
+        - Key: Application
+          Value: FydeAccessProxyASG
+
+  RedisCacheSubnetGroup:
+    Type: AWS::ElastiCache::SubnetGroup
+    Condition: RedisRequired
+    Properties:
+      CacheSubnetGroupName: FydeAccessProxy
+      Description: Redis Subnet Group for Fyde Access Proxy
+      SubnetIds: !Ref RedisSubnets
 
 Outputs:
 

--- a/docs/fyde-access-proxy/install-aws.md
+++ b/docs/fyde-access-proxy/install-aws.md
@@ -34,23 +34,29 @@ nav_order: 1
 
 ### ASG with NLB
 
-- [![launch-stack-logo]](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=fyde&templateURL=https://fyde-cloudformation-store.s3.amazonaws.com/fyde-access-proxy-aws-cf-asg.yaml){:target="_blank"}
-
 - Contains all the resources and steps needed to deploy Fyde Access Proxy in an ASG behind an NLB
 
-- The template creates a highly available / self-healing infrastructure with a minimum of 2 EC2 instances that are part of an ASG and sit behind an NLB. Required security groups and ports are included. The latest AMI for the deployed region is automatically configured, at the date of the deploy
+- The template creates a highly available / self-healing infrastructure with a minimum of 2 EC2 instances that are part of an ASG and sit behind an NLB
 
-- Download Template [here](https://url.fyde.me/fyde-proxy-aws-cf-asg){:target="_blank"}
+- All the resources are created with the principle of least privilege
+
+- The latest AMI for the deployed region is automatically configured, at the date of the deploy
+
+- When the parameter `EC2ASGDesiredCapacity` is higher than `1` (defaults to `2`), the stack will deploy a Redis Replication Group with 2 nodes, this is required for communication between Fyde Orchestrators
+
+- [![launch-stack-logo]](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=fyde&templateURL=https://fyde-cloudformation-store.s3.amazonaws.com/fyde-access-proxy-aws-cf-asg.yaml){:target="_blank"}
+
+- Template available [here](https://url.fyde.me/fyde-proxy-aws-cf-asg){:target="_blank"}
 
 ### ECS on AWS Fargate
-
-- [![launch-stack-logo]](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=fyde&templateURL=https://fyde-cloudformation-store.s3.amazonaws.com/fyde-access-proxy-aws-cf-ecs-fargate.yaml){:target="_blank"}
 
 - Contains all the resources and steps needed to deploy Fyde Access Proxy in an [ECS](https://aws.amazon.com/ecs/){:target="_blank"} cluster hosted on [AWS Fargate](https://aws.amazon.com/fargate/){:target="_blank"}
 
 - The template creates the required containers behind an NLB. Required security groups are included. The template will use the latest container versions
 
-- Download Template [here](https://url.fyde.me/fyde-proxy-aws-cf-ecs-fargate){:target="_blank"}
+- [![launch-stack-logo]](https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=fyde&templateURL=https://fyde-cloudformation-store.s3.amazonaws.com/fyde-access-proxy-aws-cf-ecs-fargate.yaml){:target="_blank"}
+
+- Template available [here](https://url.fyde.me/fyde-proxy-aws-cf-ecs-fargate){:target="_blank"}
 
 ## AMI
 

--- a/docs/fyde-access-proxy/install-bm-vm.md
+++ b/docs/fyde-access-proxy/install-bm-vm.md
@@ -139,6 +139,15 @@ nav_order: 2
     sudo chmod 600 /etc/systemd/system/fydeproxy.service.d/10-environment.conf
     ```
 
+    - For highly available instalations, access to a redis server is required for communication between Fyde Orchestrators
+
+    ```sh
+    sudo bash -c "cat >> /etc/systemd/system/fydeproxy.service.d/10-environment.conf <<EOF
+    Environment='FYDE_REDIS_HOST=<specify redis host ip or dns>'
+    Environment='FYDE_REDIS_PORT=<specify redis port, defaults for 6379 if not included>'
+    EOF"
+    ```
+
 1. Reload and start Fyde Proxy Orchestrator daemon
 
     ```sh

--- a/docs/fyde-access-proxy/scripts/install-fyde-proxy-linux.sh
+++ b/docs/fyde-access-proxy/scripts/install-fyde-proxy-linux.sh
@@ -18,19 +18,26 @@ Available parameters:
   -h \\t\\t- Show this help
   -n \\t\\t- Don't start services after install
   -p int \\t- Specify public port (1-65535), required for unattended instalation
+  -r string \\t- Specify Redis host to use for token cache <only required for HA architecture>
+  -s int \\t- Specify Redis port <optional>
   -t token \\t- Specify Fyde Access Proxy token
-  -u \\t\\t- Unattended install, skip requesting input
+  -u \\t\\t- Unattended install, skip requesting input <optional>
 
 Example for unattended instalation with Fyde Access Proxy token:
   - Specify the Fyde Access Proxy token inside quotes
 
-  $0 -n -p 443 -t \"https://xxxxxxxxxxxx\" -u
+  ${0} -p 443 -t \"https://xxxxxxxxxxxx\" -u
+
+Example for unattended instalation with Fyde Access Proxy token with Redis endpoint:
+  - Specify the Fyde Access Proxy token inside quotes
+
+  ${0} -p 443 -t \"https://xxxxxxxxxxxx\" -u -r localhost -s 6379
 
 Example for unattended instalation, skipping services start, without Fyde Access Proxy token:
   - The token can also be obtained automatically via AWS SSM/Secrets Manager
   - More info: https://fyde.github.io/docs/fyde-access-proxy/parameters/#fyde-proxy-orchestrator
 
-  $0 -n -p 443 -u
+  ${0} -n -p 443 -u
 "
     exit 0
 
@@ -38,9 +45,8 @@ Example for unattended instalation, skipping services start, without Fyde Access
 
 # Get parameters
 
-while getopts ":hnp:t:u" OPTION 2>/dev/null
-do
-    case "$OPTION" in
+while getopts ":hnp:r:s:t:u" OPTION 2>/dev/null; do
+    case "${OPTION}" in
         h)
             program_help
         ;;
@@ -48,24 +54,30 @@ do
             NO_START_SVC="true"
         ;;
         p)
-            PUBLIC_PORT="$OPTARG"
+            PUBLIC_PORT="${OPTARG}"
+        ;;
+        r)
+            REDIS_HOST="${OPTARG}"
+        ;;
+        s)
+            REDIS_PORT="${OPTARG}"
         ;;
         t)
-            PROXY_TOKEN="$OPTARG"
+            PROXY_TOKEN="${OPTARG}"
         ;;
         u)
             UNATTENDED_INSTALL="true"
         ;;
         \?)
-            echo "Invalid option: -$OPTARG"
+            echo "Invalid option: -${OPTARG}"
             exit 3
         ;;
         :)
-            echo "Option -$OPTARG requires an argument." >&2
+            echo "Option -${OPTARG} requires an argument." >&2
             exit 3
         ;;
         *)
-            echo "$OPTARG is an unrecognized option"
+            echo "${OPTARG} is an unrecognized option"
             exit 3
         ;;
     esac
@@ -86,10 +98,8 @@ function log_entry() {
 
 # Prepare inputs
 
-if [[ "${UNATTENDED_INSTALL:-}" == "true" ]]
-then
-    if [[ -z "${PUBLIC_PORT:-}" ]]
-    then
+if [[ "${UNATTENDED_INSTALL:-}" == "true" ]] || ! [[ -t 0 ]]; then
+    if [[ -z "${PUBLIC_PORT:-}" ]]; then
         log_entry "ERROR" "Unattended install requires public port (-h for more info)"
         exit 1
     fi
@@ -99,15 +109,19 @@ else
     read -r -p "Specify Fyde Access Proxy public port (443): " PUBLIC_PORT
     PUBLIC_PORT=${PUBLIC_PORT:-"443"}
 
-    while [[ -z "${PROXY_TOKEN:-}" ]];
-    do
+    while [[ -z "${PROXY_TOKEN:-}" ]]; do
         read -r -p "Paste the Fyde Access Proxy enrollment link (hidden): " -s PROXY_TOKEN
         echo ""
-        if [[ -z "${PROXY_TOKEN:-}" ]]
-        then
+        if [[ -z "${PROXY_TOKEN:-}" ]]; then
             log_entry "ERROR" "Fyde Access Proxy enrollment link cannot be empty"
         fi
     done
+
+    read -r -p "Specify Redis host (only required for HA architecture): " REDIS_HOST
+    if [ -n "${REDIS_HOST:-}" ]; then
+        read -r -p "Specify Redis port (6379): " REDIS_PORT
+        REDIS_PORT=${REDIS_PORT:-"6379"}
+    fi
 fi
 
 # Pre-requisites
@@ -131,9 +145,8 @@ log_entry "INFO" "Install Envoy Proxy"
 yum -y install envoy
 systemctl enable envoy
 
-if [ "$PUBLIC_PORT" -lt 1024 ];
-then
-    log_entry "INFO" "Add CAP_NET_BIND_SERVICE to Envoy using a service unit override"
+if [ "${PUBLIC_PORT}" -lt 1024 ]; then
+    log_entry "INFO" "Configure Envoy Proxy"
     mkdir -p /etc/systemd/system/envoy.service.d
     cat > /etc/systemd/system/envoy.service.d/10-add-cap-net-bind.conf <<EOF
 [Service]
@@ -143,11 +156,11 @@ AmbientCapabilities=CAP_NET_BIND_SERVICE
 SecureBits=keep-caps
 EOF
     chmod 600 /etc/systemd/system/envoy.service.d/10-add-cap-net-bind.conf
+
     systemctl --system daemon-reload
 fi
 
-if [[ "${NO_START_SVC:-}" == true ]]
-then
+if [[ "${NO_START_SVC:-}" == true ]]; then
     log_entry "INFO" "Skip Envoy Proxy daemon start"
 else
     log_entry "INFO" "Start Envoy Proxy daemon"
@@ -160,20 +173,28 @@ log_entry "INFO" "Install Fyde Proxy Orchestrator"
 yum -y install fydeproxy
 systemctl enable fydeproxy
 
-log_entry "INFO" "Configure environment using a service unit override"
-mkdir -p /etc/systemd/system/fydeproxy.service.d
-echo -e "[Service]\nEnvironment='FYDE_ENVOY_LISTENER_PORT=${PUBLIC_PORT}'" \
-    > /etc/systemd/system/fydeproxy.service.d/10-environment.conf
-if [[ -n "${PROXY_TOKEN:-}" ]]
-then
-    echo -e "Environment='FYDE_ENROLLMENT_TOKEN=${PROXY_TOKEN}'" \
-        >> /etc/systemd/system/fydeproxy.service.d/10-environment.conf
+log_entry "INFO" "Configure Fyde Proxy Orchestrator"
+
+UNIT_OVERRIDE=("[Service]" "Environment='FYDE_ENVOY_LISTENER_PORT=${PUBLIC_PORT}'")
+
+if [[ -n "${PROXY_TOKEN:-}" ]]; then
+    UNIT_OVERRIDE+=("Environment='FYDE_ENROLLMENT_TOKEN=${PROXY_TOKEN}'")
 fi
+
+if [[ -n "${REDIS_HOST:-}" ]]; then
+    UNIT_OVERRIDE+=("Environment='FYDE_REDIS_HOST=${REDIS_HOST}'")
+    if [[ -n "${REDIS_PORT:-}" ]]; then
+        UNIT_OVERRIDE+=("Environment='FYDE_REDIS_PORT=${REDIS_PORT}'")
+    fi
+fi
+
+mkdir -p /etc/systemd/system/fydeproxy.service.d
+printf "%s\n" "${UNIT_OVERRIDE[@]}" > /etc/systemd/system/fydeproxy.service.d/10-environment.conf
 chmod 600 /etc/systemd/system/fydeproxy.service.d/10-environment.conf
+
 systemctl --system daemon-reload
 
-if [[ "${NO_START_SVC:-}" == true ]]
-then
+if [[ "${NO_START_SVC:-}" == "true" ]]; then
     log_entry "INFO" "Skip Fyde Proxy Orchestrator start"
 else
     log_entry "INFO" "Start Fyde Proxy Orchestrator daemon"
@@ -181,8 +202,7 @@ else
 fi
 
 log_entry "INFO" "Configure the firewall"
-if systemctl status firewalld &> /dev/null
-then
+if systemctl status firewalld &> /dev/null; then
     firewall-cmd --zone=public --add-port="${PUBLIC_PORT}/tcp" --permanent
     firewall-cmd --reload
 else
@@ -193,8 +213,7 @@ log_entry "INFO" "Check logs:"
 echo "tail /var/log/envoy/envoy.log -f"
 echo "journalctl -u fydeproxy -f"
 
-if [[ "${NO_START_SVC:-}" == true ]]
-then
+if [[ "${NO_START_SVC:-}" == true ]]; then
     log_entry "INFO" "Start services:"
     echo "systemctl start envoy"
     echo "systemctl start fydeproxy"

--- a/docs/releases/fyde-deployment-scripts.md
+++ b/docs/releases/fyde-deployment-scripts.md
@@ -6,6 +6,11 @@ parent: Releases
 ---
 # Fyde Deployment Scripts
 
+### 2020.09.19
+
+- [Cloudformation] Add redis configuration for ASG
+- [Bootstrap Scripts] Add redis configuration parameters
+
 ### 2020.09.16
 
 - [Cloudformation] Add AssociatePublicIpAddress configuration for ASG


### PR DESCRIPTION
# What

- When the parameter `EC2ASGDesiredCapacity` is higher than `1` (defaults to `2`), the stack will now deploy a Redis Replication Group with 2 nodes, this is required for communication between Fyde Orchestrators

# Test

- Tested upgrade path successfully from currently available stack
- Checks inside one instance (partly redacted):
```sh
[ec2-user@ip-10-200-0-99 ~]$ sudo cat /etc/systemd/system/fydeproxy.service.d/10-environment.conf
[Service]
Environment='FYDE_ENVOY_LISTENER_PORT=443'
Environment='FYDE_REDIS_HOST=xxxxxx.oy8bqq.ng.0001.euw1.cache.amazonaws.com'
Environment='FYDE_REDIS_PORT=6379'

[ec2-user@ip-10-200-0-99 ~]$ nc xxxxxx.oy8bqq.ng.0001.euw1.cache.amazonaws.com 6379
keys *
*5
$46
proxy_key_caaxxxxxf2a8
$57
discoverer_sync_wait_caa8xxxxxx5cf4f2a8
$55
upstream_resources_caa80xxxxxx4f2a8
$75
tls_sessions_ticket_caa806xxxxxx54188
$60
upstream_resources_caa806xxxxx4f2a8_time
```