### PR TITLE
Add Cloudwatch logging to ASG

### DIFF
--- a/docs/fyde-access-proxy/aws-cloudformation/fyde-access-proxy-aws-cf-asg.yaml
+++ b/docs/fyde-access-proxy/aws-cloudformation/fyde-access-proxy-aws-cf-asg.yaml
@@ -98,19 +98,43 @@ Parameters:
     Description: >-
       Select the Subnet Ids to use for the redis instances.
       Required although Redis is only created when EC2ASGDesiredCapacity is not 1.
-      NOTE: Use Private Subnets
+      NOTE: Use Private Subnets.
+
+  CloudWatchLogs:
+    Description: >-
+      Send '/var/log/message' logs to CloudWatch.
+      Default is true.
+    Type: String
+    Default: true
+    AllowedValues:
+      - true
+      - false
+
+  CloudWatchLogsRetentionInDays:
+    Description: Days to keep CloudWatch logs (0 = never delete).
+    Default: 7
+    Type: Number
+    MinValue: 0
 
 Conditions:
 
   RedisRequired: !Not [!Equals [!Ref EC2ASGDesiredCapacity, 1]]
+  CloudWatchLogsEnabled: !Equals [!Ref CloudWatchLogs, true]
 
 Resources:
 
 #
-# Find AMI
+# Get Latest AMI
 #
 
-  DescribeImagesRole:
+  CloudWatchLogsGroupGetLatestAMI:
+    Type: AWS::Logs::LogGroup
+    Condition: CloudWatchLogsEnabled
+    Properties:
+      LogGroupName: '/aws/lambda/FydeAccessProxyGetLatestAMI'
+      RetentionInDays: !Ref CloudWatchLogsRetentionInDays
+
+  RoleGetLatestAMI:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
@@ -127,16 +151,23 @@ Resources:
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
-              - Action: ec2:DescribeImages
-                Effect: Allow
+              - Effect: Allow
+                Action: ec2:DescribeImages
                 Resource: '*'
+              - Effect: Allow
+                Action:
+                  - 'logs:CreateLogStream'
+                  - 'logs:PutLogEvents'
+                Resource: !GetAtt CloudWatchLogsGroupGetLatestAMI.Arn
 
-  GetLatestAMI:
+  LambdaGetLatestAMI:
     Type: AWS::Lambda::Function
+    DependsOn: CloudWatchLogsGroupGetLatestAMI
     Properties:
+      FunctionName: FydeAccessProxyGetLatestAMI
       Runtime: python3.6
       Handler: index.handler
-      Role: !Sub ${DescribeImagesRole.Arn}
+      Role: !Sub ${RoleGetLatestAMI.Arn}
       Timeout: 60
       Code:
         ZipFile: |
@@ -165,11 +196,16 @@ Resources:
             except:
               traceback.print_last()
               cfnresponse.send(event, context, cfnresponse.FAIL, {}, "ok")
+      Tags:
+        - Key: Name
+          Value: FydeAccessProxy
+        - Key: Application
+          Value: FydeAccessProxyASG
 
-  FydeAccessProxyAmiLatest:
+  CustomGetLatestAMI:
     Type: Custom::FindAMI
     Properties:
-      ServiceToken: !Sub ${GetLatestAMI.Arn}
+      ServiceToken: !Sub ${LambdaGetLatestAMI.Arn}
       Owner: '766535289950'
       Name: 'amazonlinux-2-base_*'
       Architecture: x86_64
@@ -187,6 +223,8 @@ Resources:
       Tags:
         - Key: Name
           Value: FydeAccessProxy
+        - Key: Application
+          Value: FydeAccessProxyASG
 
 #
 # NLB
@@ -323,7 +361,7 @@ Resources:
     Properties:
       AssociatePublicIpAddress: !Ref EC2AssociatePublicIpAddress
       KeyName: !Ref EC2KeyName
-      ImageId: !Ref FydeAccessProxyAmiLatest
+      ImageId: !Ref CustomGetLatestAMI
       SecurityGroups:
         - !Ref InboundEC2SecGroup
         - !Ref ResourceSecGroup
@@ -336,6 +374,9 @@ Resources:
             - "\n"
             - - '#!/bin/bash'
               - 'set -xeuo pipefail'
+              - !If [ CloudWatchLogsEnabled, 'curl -sL "https://url.fyde.me/config-ec2-cloudwatch-logs" | bash -s -- \', Ref 'AWS::NoValue' ]
+              - !If [ CloudWatchLogsEnabled, '  -l "/aws/ec2/FydeAccessProxy" \', Ref 'AWS::NoValue' ]
+              - !If [ CloudWatchLogsEnabled, !Sub '  -r "${AWS::Region}"', !Ref 'AWS::NoValue' ]
               - 'curl -sL "https://url.fyde.me/install-fyde-proxy-linux" | bash -s -- \'
               - '  -u \'
               - !Join
@@ -402,6 +443,27 @@ Resources:
       Roles:
         - !Ref InstanceRole
 
+  InstancePolicyCloudWatchLogsEC2:
+    Type: 'AWS::IAM::Policy'
+    Condition: CloudWatchLogsEnabled
+    Properties:
+      PolicyName: CloudWatchLogsEC2
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - 'logs:CreateLogGroup'
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+            Resource: !GetAtt CloudWatchLogsGroupEC2.Arn
+          - Effect: Allow
+            Action:
+              - 'logs:DescribeLogStreams'
+            Resource: '*'
+      Roles:
+        - !Ref InstanceRole
+
 #
 # Redis
 #
@@ -433,6 +495,17 @@ Resources:
       CacheSubnetGroupName: FydeAccessProxy
       Description: Redis Subnet Group for Fyde Access Proxy
       SubnetIds: !Ref RedisSubnets
+
+#
+# CloudWatch Logs
+#
+
+  CloudWatchLogsGroupEC2:
+    Type: AWS::Logs::LogGroup
+    Condition: CloudWatchLogsEnabled
+    Properties:
+      LogGroupName: '/aws/ec2/FydeAccessProxy'
+      RetentionInDays: !Ref CloudWatchLogsRetentionInDays
 
 Outputs:
 

--- a/docs/fyde-access-proxy/aws-cloudformation/fyde-access-proxy-aws-cf-asg.yaml
+++ b/docs/fyde-access-proxy/aws-cloudformation/fyde-access-proxy-aws-cf-asg.yaml
@@ -116,6 +116,19 @@ Parameters:
     Type: Number
     MinValue: 0
 
+  FydeProxyLoglevel:
+    Description: >-
+      Set the Fyde Proxy orchestrator log level.
+      Default is info.
+    Type: String
+    Default: info
+    AllowedValues:
+      - debug
+      - info
+      - warning
+      - error
+      - critical
+
 Conditions:
 
   RedisRequired: !Not [!Equals [!Ref EC2ASGDesiredCapacity, 1]]
@@ -381,7 +394,7 @@ Resources:
               - '  -u \'
               - !Join
                 - ' '
-                - - !Sub '  -p "${FydeAccessProxyPublicPort}"'
+                - - !Sub ' -p "${FydeAccessProxyPublicPort}" -l "${FydeProxyLoglevel}" '
                   - !If [ RedisRequired, '\', !Ref 'AWS::NoValue' ]
               - !If [ RedisRequired, !Sub '  -r "${RedisCacheReplicationGroup.PrimaryEndPoint.Address}" \', !Ref 'AWS::NoValue' ]
               - !If [ RedisRequired, !Sub '  -s "${RedisCacheReplicationGroup.PrimaryEndPoint.Port}"', !Ref 'AWS::NoValue' ]

--- a/docs/fyde-access-proxy/aws-cloudformation/fyde-access-proxy-aws-cf-ecs-fargate.yaml
+++ b/docs/fyde-access-proxy/aws-cloudformation/fyde-access-proxy-aws-cf-ecs-fargate.yaml
@@ -21,6 +21,19 @@ Parameters:
     MinValue: 1
     MaxValue: 65535
 
+  fydeAccessProxyLoglevel:
+    Description: >-
+      Set the Fyde Proxy orchestrator log level.
+      Default is info.
+    Type: String
+    Default: info
+    AllowedValues:
+      - debug
+      - info
+      - warning
+      - error
+      - critical
+
   vpcId:
     Type: AWS::EC2::VPC::Id
     Description: Select the Virtual Private Cloud (VPC) to use
@@ -278,6 +291,8 @@ Resources:
           Environment:
             - Name: FYDE_ENVOY_LISTENER_PORT
               Value: !Ref fydeAccessProxyPublicPort
+            - Name: FYDE_LOGLEVEL
+              Value: !Ref fydeAccessProxyLoglevel
             - !If
               - createRedis
               - Name: FYDE_REDIS_HOST

--- a/docs/fyde-access-proxy/install-bm-vm.md
+++ b/docs/fyde-access-proxy/install-bm-vm.md
@@ -49,19 +49,27 @@ nav_order: 2
 
     Available parameters:
       -h        - Show this help
+      -l string - Loglevel (debug, info, warning, error, critical), defaults to info.
       -n        - Don't start services after install
       -p int    - Specify public port (1-65535), required for unattended instalation
+      -r string - Specify Redis host to use for token cache <only required for HA architecture>
+      -s int    - Specify Redis port <optional>
       -t token  - Specify Fyde Access Proxy token
-      -u        - Unattended install, skip requesting input
+      -u        - Unattended install, skip requesting input <optional>
 
     Example for unattended instalation with Fyde Access Proxy token:
       - Specify the Fyde Access Proxy token inside quotes
 
       ./install-fyde-proxy-linux.sh -p 443 -t "https://xxxxxxxxxxxx" -u
 
+    Example for unattended instalation with Fyde Access Proxy token with Redis endpoint:
+      - Specify the Fyde Access Proxy token inside quotes
+
+      ./install-fyde-proxy-linux.sh -p 443 -t "https://xxxxxxxxxxxx" -u -r localhost -s 6379
+
     Example for unattended instalation, skipping services start, without Fyde Access Proxy token:
-     - The token can also be obtained automatically via AWS SSM/Secrets Manager
-     - More info: https://fyde.github.io/docs/fyde-access-proxy/parameters/#fyde-proxy-orchestrator
+      - The token can also be obtained automatically via AWS SSM/Secrets Manager
+      - More info: https://fyde.github.io/docs/fyde-access-proxy/parameters/#fyde-proxy-orchestrator
 
       ./install-fyde-proxy-linux.sh -n -p 443 -u
     ```

--- a/docs/fyde-access-proxy/scripts/config-ec2-cloudwatch-logs.sh
+++ b/docs/fyde-access-proxy/scripts/config-ec2-cloudwatch-logs.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019-present, Fyde, Inc.
+# All rights reserved.
+#
+
+# Set error handling
+
+set -euo pipefail
+
+# Set help
+
+function program_help {
+
+    echo -e "Configure awslogs package
+
+Available parameters:
+  -h \\t\\t- Show this help
+  -l \\t\\t- Specify Log Stream Name
+  -r \\t\\t- Specify Log Region
+"
+    exit 0
+
+}
+
+# Get parameters
+
+while getopts ":hl:r:" OPTION 2>/dev/null; do
+    case "${OPTION}" in
+        h)
+            program_help
+        ;;
+        l)
+            LOG_STREAM_NAME="${OPTARG}"
+        ;;
+        r)
+            LOG_REGION="${OPTARG}"
+        ;;
+        \?)
+            echo "Invalid option: -${OPTARG}"
+            exit 3
+        ;;
+        :)
+            echo "Option -${OPTARG} requires an argument." >&2
+            exit 3
+        ;;
+        *)
+            echo "${OPTARG} is an unrecognized option"
+            exit 3
+        ;;
+    esac
+done
+
+# Functions
+
+function log_entry() {
+
+    local LOG_TYPE="${1:?Needs log type}"
+    local LOG_MSG="${2:?Needs log message}"
+    local COLOR='\033[93m'
+    local ENDCOLOR='\033[0m'
+
+    echo -e "${COLOR}$(date "+%Y-%m-%d %H:%M:%S") [$LOG_TYPE] ${LOG_MSG}${ENDCOLOR}"
+
+}
+
+# Run
+
+if [[ -z "${LOG_STREAM_NAME}" ]]; then
+    log_entry "ERROR" "Requires Log Stream Name (-h for more info)"
+    exit 1
+fi
+
+if [[ -z "${LOG_REGION}" ]]; then
+    log_entry "ERROR" "Requires Log Region (-h for more info)"
+    exit 1
+fi
+
+log_entry "INFO" "Install awslogs"
+yum install -y awslogs
+
+log_entry "INFO" "Configure awslogs"
+
+cat > /etc/awslogs/awscli.conf <<EOF
+[plugins]
+cwlogs = cwlogs
+[default]
+region = ${LOG_REGION}
+EOF
+chmod 600 /etc/awslogs/awscli.conf
+
+cat > /etc/awslogs/awslogs.conf <<EOF
+[general]
+state_file = /var/lib/awslogs/agent-state
+
+[/var/log/messages]
+file = /var/log/messages
+log_group_name = ${LOG_STREAM_NAME}
+log_stream_name = {instance_id}
+datetime_format = %Y-%m-%dT%H:%M:%S%z
+initial_position = start_of_file
+time_zone = UTC
+EOF
+chmod 600 /etc/awslogs/awslogs.conf
+
+log_entry "INFO" "Enable and start service"
+systemctl enable awslogsd.service
+systemctl restart awslogsd.service

--- a/docs/fyde-access-proxy/scripts/install-fyde-proxy-linux.sh
+++ b/docs/fyde-access-proxy/scripts/install-fyde-proxy-linux.sh
@@ -16,6 +16,7 @@ function program_help {
 
 Available parameters:
   -h \\t\\t- Show this help
+  -l string \\t- Loglevel (debug, info, warning, error, critical), defaults to info.
   -n \\t\\t- Don't start services after install
   -p int \\t- Specify public port (1-65535), required for unattended instalation
   -r string \\t- Specify Redis host to use for token cache <only required for HA architecture>
@@ -45,10 +46,13 @@ Example for unattended instalation, skipping services start, without Fyde Access
 
 # Get parameters
 
-while getopts ":hnp:r:s:t:u" OPTION 2>/dev/null; do
+while getopts ":hl:np:r:s:t:u" OPTION 2>/dev/null; do
     case "${OPTION}" in
         h)
             program_help
+        ;;
+        l)
+            LOGLEVEL="${OPTARG:-info}"
         ;;
         n)
             NO_START_SVC="true"
@@ -176,6 +180,7 @@ systemctl enable fydeproxy
 log_entry "INFO" "Configure Fyde Proxy Orchestrator"
 
 UNIT_OVERRIDE=("[Service]" "Environment='FYDE_ENVOY_LISTENER_PORT=${PUBLIC_PORT}'")
+UNIT_OVERRIDE+=("Environment='FYDE_LOGLEVEL=${LOGLEVEL}'")
 
 # Update tmp dir to avoid tmpfiles.d removing our uncompressed PyInstaller bundle
 UNIT_OVERRIDE+=("Environment='TMPDIR=/var/run/fydeproxy'")

--- a/docs/releases/fyde-deployment-scripts.md
+++ b/docs/releases/fyde-deployment-scripts.md
@@ -6,6 +6,10 @@ parent: Releases
 ---
 # Fyde Deployment Scripts
 
+### 2020.09.28
+
+- [Cloudformation] Add configuration to set fydeproxy service loglevel
+
 ### 2020.09.19
 
 - [Cloudformation] Add redis configuration for ASG

--- a/docs/releases/fyde-deployment-scripts.md
+++ b/docs/releases/fyde-deployment-scripts.md
@@ -9,6 +9,7 @@ parent: Releases
 ### 2020.09.19
 
 - [Cloudformation] Add redis configuration for ASG
+- [Cloudformation] Add configuration to send logs to Cloudformation for ASG
 - [Bootstrap Scripts] Add redis configuration parameters
 
 ### 2020.09.16


### PR DESCRIPTION
# Description

- Troubleshooting issues in AWS is hard, having to ssh into an instance to troubleshoot the problem is not the best solution
- This PR adds the option to send the system logs (`/var/log/messages`) to CloudWatch
- Add and organize new troubleshooting options
- Add table of content to pages
- Requires https://github.com/fyde/docs/pull/115

# Examples

- New parameters to configure Cloudwatch

  <img width="1018" alt="CF-Param" src="https://user-images.githubusercontent.com/19713226/93689717-225b4a00-fac9-11ea-80b9-56758ed52da5.png">

- Example of created log groups

  <img width="917" alt="CW-Log-Groups" src="https://user-images.githubusercontent.com/19713226/93689728-34d58380-fac9-11ea-8bdb-205caa495a20.png">

- Example of log

  ![image](https://user-images.githubusercontent.com/19713226/93689773-9d246500-fac9-11ea-8174-996508e91bad.png)

