### PR TITLE
Update CentOS environment configuration

### DIFF
--- a/docs/fyde-access-proxy/install-bm-vm.md
+++ b/docs/fyde-access-proxy/install-bm-vm.md
@@ -135,6 +135,8 @@ nav_order: 2
 
 1. Configure environment using a service unit override
 
+    - We need to set the temporary directory due to `tmpfiles.d` daemon incompatibility
+
     ```sh
     sudo mkdir -p /etc/systemd/system/fydeproxy.service.d
 
@@ -142,6 +144,7 @@ nav_order: 2
     [Service]
     Environment='FYDE_ENROLLMENT_TOKEN=<paste here your Fyde Access Proxy enrollment link>'
     Environment='FYDE_ENVOY_LISTENER_PORT=<replace with the corresponding Fyde Access Proxy port, as configured in Fyde Enterprise Console>'
+    Environment='TMPDIR=/var/run/fydeproxy'
     EOF"
 
     sudo chmod 600 /etc/systemd/system/fydeproxy.service.d/10-environment.conf

--- a/docs/fyde-access-proxy/scripts/install-fyde-proxy-linux.sh
+++ b/docs/fyde-access-proxy/scripts/install-fyde-proxy-linux.sh
@@ -177,6 +177,9 @@ log_entry "INFO" "Configure Fyde Proxy Orchestrator"
 
 UNIT_OVERRIDE=("[Service]" "Environment='FYDE_ENVOY_LISTENER_PORT=${PUBLIC_PORT}'")
 
+# Update tmp dir to avoid tmpfiles.d removing our uncompressed PyInstaller bundle
+UNIT_OVERRIDE+=("Environment='TMPDIR=/var/run/fydeproxy'")
+
 if [[ -n "${PROXY_TOKEN:-}" ]]; then
     UNIT_OVERRIDE+=("Environment='FYDE_ENROLLMENT_TOKEN=${PROXY_TOKEN}'")
 fi


### PR DESCRIPTION
- Adds `TMPDIR` variable
- Test in VM
```sh
[vagrant@localhost ~]$ sudo cat /etc/systemd/system/fydeproxy.service.d/10-environment.conf
Environment='TMPDIR=/var/run/fydeproxy'
Environment='FYDE_ENROLLMENT_TOKEN=test_token'
```